### PR TITLE
Error when uploading to GridFS via Puma (body stored in file)

### DIFF
--- a/lib/tus/input.rb
+++ b/lib/tus/input.rb
@@ -12,7 +12,7 @@ module Tus
     end
 
     def eof?
-      @eof
+      @eof || @input.eof?
     end
 
     def rewind

--- a/lib/tus/input.rb
+++ b/lib/tus/input.rb
@@ -12,7 +12,7 @@ module Tus
     end
 
     def eof?
-      @eof || @input.eof?
+      @eof || (@input.eof? if @input.respond_to?(:eof?))
     end
 
     def rewind

--- a/test/gridfs_test.rb
+++ b/test/gridfs_test.rb
@@ -79,6 +79,36 @@ describe Tus::Storage::Gridfs do
       assert_equal 5, new_info[:length]
       assert_operator new_info[:uploadDate], :>, original_info[:uploadDate]
     end
+
+    it "patch with Tus::Input input from file" do
+      begin
+        @storage.create_file("foo")
+
+        tmpfile = Tempfile.new
+        tmpfile.write("hello world")
+        tmpfile.rewind
+
+        input = Tus::Input.new(tmpfile)
+
+        @storage.patch_file("foo", input)
+        assert_equal 1, @storage.bucket.chunks_collection.find.count
+        assert_equal "hello world", @storage.read_file("foo")
+      ensure
+        tmpfile.close!
+      end
+    end
+
+    it "patch with Tus::Input from string" do
+      @storage.create_file("foo")
+
+      io = StringIO.new("hello world")
+
+      input = Tus::Input.new(io)
+
+      @storage.patch_file("foo", input)
+      assert_equal 1, @storage.bucket.chunks_collection.find.count
+      assert_equal "hello world", @storage.read_file("foo")
+    end
   end
 
   describe "#get_file" do


### PR DESCRIPTION
Hi,

I've encountered an issue when trying to upload to GridFS via Puma due to the input reaching eof before the Tus::Input wrapper would indicate it.

Please find attached some tests and a fix for that.