### PR TITLE
It allows to pass empty string as metadata value

### DIFF
--- a/lib/tus/info.rb
+++ b/lib/tus/info.rb
@@ -74,7 +74,7 @@ module Tus
 
       hash = Hash[pairs]
       hash.each do |key, value|
-        hash[key] = Base64.decode64(value)
+        hash[key] = value && Base64.decode64(value) || ''
       end
 
       hash

--- a/lib/tus/server.rb
+++ b/lib/tus/server.rb
@@ -228,7 +228,7 @@ module Tus
       upload_metadata.split(",").each do |string|
         key, value = string.split(" ")
 
-        error!(400, "Invalid Upload-Metadata header") if key.nil? || value.nil?
+        error!(400, "Invalid Upload-Metadata header") if key.nil?
         error!(400, "Invalid Upload-Metadata header") if key.ord > 127
         error!(400, "Invalid Upload-Metadata header") if key =~ /,| /
 


### PR DESCRIPTION
Hello! I tried to pass S3 prefix as metadata and in some cases, when prefix is empty it raises error. This commit fixes it. I didn't found anything about value can't be blank in tus spec, I guess it should be permitted.