### PR TITLE
Add behind-proxy feature

### DIFF
--- a/lib/tus/server.rb
+++ b/lib/tus/server.rb
@@ -28,6 +28,8 @@ module Tus
     opts[:disposition]     = "inline"
     opts[:download_url]    = nil
 
+    opts[:behind_proxy]    = true
+    
     plugin :all_verbs
     plugin :default_headers, {"Content-Type" => ""}
     plugin :delete_empty_headers
@@ -393,7 +395,7 @@ module Tus
     def storage
       opts[:storage] || Tus::Storage::Filesystem.new("data")
     end
-
+    
     def max_size
       opts[:max_size]
     end

--- a/lib/tus/server.rb
+++ b/lib/tus/server.rb
@@ -27,7 +27,6 @@ module Tus
     opts[:expiration_time] = 7*24*60*60
     opts[:disposition]     = "inline"
     opts[:download_url]    = nil
-
     opts[:behind_proxy]    = true
     
     plugin :all_verbs
@@ -399,13 +398,17 @@ module Tus
     def max_size
       opts[:max_size]
     end
-
+    
     def expiration_time
       opts[:expiration_time]
     end
 
     def expiration_interval
       opts[:expiration_interval]
+    end
+    
+    def behind_proxy
+      opts[:behind_proxy]
     end
   end
 end


### PR DESCRIPTION
Allow tus-ruby-server to respect X-Forwarded-* and similar headers when used with reverse proxy.